### PR TITLE
avoid AttributeError: 'NoneType' object has no attribute 'append'

### DIFF
--- a/lpod/document.py
+++ b/lpod/document.py
@@ -603,7 +603,8 @@ class odf_document(object):
         # Insert it!
         if existing is not None:
             container.delete(existing)
-        container.append(style)
+        if container:
+            container.append(style)
         return style.get_name()
 
 


### PR DESCRIPTION
`AttributeError: 'NoneType' object has no attribute 'append'` occured.
I did not understand what is the reason of that error, so I did only quick fix.

In that case,
`style` is `{'_odf_element__element': <Element {urn:oasis:names:tc:opendocument:xmlns:style:1.0}font-face at 0x1057646c8>}` ,
`name` is `u'Nimbus Mono L'`
(confirm with using `pprint` )
